### PR TITLE
fix: Adding passes to the renderer would cause subsequent pass indexes to become broken.

### DIFF
--- a/src/Renderer/Passes/GLOpaqueGeomsPass.js
+++ b/src/Renderer/Passes/GLOpaqueGeomsPass.js
@@ -308,7 +308,7 @@ class GLOpaqueGeomsPass extends GLStandardGeomsPass {
     // if (this.newItemsReadyForLoading()) this.finalize()
     // renderstate.drawItemsTexture = this.__drawItemsTexture
 
-    renderstate.passIndex = this.__passIndex
+    renderstate.passIndex = this.passIndex
 
     const gl = this.__gl
     gl.disable(gl.BLEND)

--- a/src/Renderer/Passes/GLPass.js
+++ b/src/Renderer/Passes/GLPass.js
@@ -17,7 +17,7 @@ class GLPass extends ParameterOwner {
   constructor() {
     super()
     this.enabled = true
-    this.__passIndex = 0
+    this.passIndex = 0
 
     const enabledParam = this.addParameter(new BooleanParameter('Enabled', true))
     enabledParam.on('valueChanged', () => (this.enabled = enabledParam.getValue()))
@@ -45,7 +45,6 @@ class GLPass extends ParameterOwner {
     this.renderer = renderer
     this.__renderer = renderer
     this.passIndex = passIndex
-    this.__passIndex = passIndex
   }
 
   /**

--- a/src/Renderer/Passes/GLTransparentGeomsPass.js
+++ b/src/Renderer/Passes/GLTransparentGeomsPass.js
@@ -473,7 +473,7 @@ class GLTransparentGeomsPass extends GLStandardGeomsPass {
       {
         const unif = renderstate.unifs.passId
         if (unif) {
-          gl.uniform1i(unif.location, this.__passIndex)
+          gl.uniform1i(unif.location, this.passIndex)
         }
       }
 


### PR DESCRIPTION
e.g. Adding a new pass would break the Overlay pass and then Handles would not work.