### PR TITLE
fix: The Engine became incompatible with its plugins due to a variable rename

### DIFF
--- a/src/Renderer/Passes/GLPass.js
+++ b/src/Renderer/Passes/GLPass.js
@@ -45,6 +45,7 @@ class GLPass extends ParameterOwner {
     this.renderer = renderer
     this.__renderer = renderer
     this.passIndex = passIndex
+    this.__passIndex = passIndex // for backwards compatibility
   }
 
   /**
@@ -53,6 +54,7 @@ class GLPass extends ParameterOwner {
    */
   setPassIndex(passIndex) {
     this.passIndex = passIndex
+    this.__passIndex = passIndex // for backwards compatibility
   }
 
   /**


### PR DESCRIPTION
This fix puts back the old name to address this compatibility issue.