### PR TITLE
fix: indices in the renderer became broken after removing a geometry from the renderer.

### DIFF
--- a/testing-e2e/add-remove-items-from-renderer.html
+++ b/testing-e2e/add-remove-items-from-renderer.html
@@ -44,9 +44,16 @@
 
         if (data === 'variant-01') {
           scene.getRoot().removeChild(scene.getRoot().getChildIndex(geomItem0))
+          // Modify the item that is not being removed.
+          // Note: this used to cause a crash because indices were confused in the multi-draw class.
+          geomItem1.getParameter('Geometry').getValue().getParameter('Loops').setValue(100)
           window.postMessage(`done-${data}`)
         } else if (data === 'variant-02') {
           scene.getRoot().removeChild(scene.getRoot().getChildIndex(geomItem1))
+          // Modify the class again, after it has been removed from the renderer.
+          // Note: Our GLGeomLibrary still updates the buffers. It doesn't know that
+          // no GeomItems track this geom. We need to add ref counting...
+          geomItem1.getParameter('Geometry').getValue().getParameter('Loops').setValue(12)
           window.postMessage(`done-${data}`)
         } else if (data === 'variant-03') {
           scene.getRoot().addChild(geomItem0)


### PR DESCRIPTION
Note: this only caused problems if subsequently another geometries data was changes.
Note: this bug did not affect Safari/Firefox, as it only occurred on the new multi-draw code path.

The following exception call stack might have occurred.
```
Uncaught TypeError: Cannot read property 'geomItem' of undefined
    at GLGeomItemSetMultiDraw.js:51
    at EventEmitter.js:190
    at Array.forEach (<anonymous>)
    at GLGeomLibrary.emit (EventEmitter.js:187)
    at GLGeomLibrary.uploadBuffers (GLGeomLibrary.js:404)
    at GLGeomLibrary.js:440
    at Set.forEach (<anonymous>)
    at GLGeomLibrary.cleanGeomBuffers (GLGeomLibrary.js:439)
    at GLGeomLibrary.bind (GLGeomLibrary.js:464)
    at GLShaderGeomSets.bindShader (GLShaderGeomSets.js:111)
```