### PR TITLE
fix: canvas is now immediately resized to fit its parent container

### DIFF
--- a/plop-templates/e2e-test-page.html
+++ b/plop-templates/e2e-test-page.html
@@ -28,9 +28,7 @@
         console.log(msg)
         window.postMessage(msg)
       }
-      renderer.once('resized', () => {
-        postMessage('done-loading')
-      })
+      postMessage('done-loading')
 
       // {{openCommentBlock}} Messages handler.
       const handleMessage = (event) => {

--- a/src/Renderer/GLBaseRenderer.js
+++ b/src/Renderer/GLBaseRenderer.js
@@ -496,7 +496,7 @@ class GLBaseRenderer extends ParameterOwner {
    *
    * @private
    */
-  __handleResize(width, height) {
+  handleResize(width, height) {
     if (this.__xrViewportPresenting) {
       return
     }
@@ -601,10 +601,11 @@ class GLBaseRenderer extends ParameterOwner {
           return
         }
 
-        this.__handleResize(entry.contentRect.width, entry.contentRect.height)
+        this.handleResize(entry.contentRect.width, entry.contentRect.height)
       }
     })
 
+    this.handleResize(this.__glcanvas.parentElement.clientWidth, this.__glcanvas.parentElement.clientHeight)
     this.resizeObserver.observe(this.__glcanvas.parentElement)
 
     webglOptions.preserveDrawingBuffer = true

--- a/testing-e2e/add-remove-items-from-renderer.html
+++ b/testing-e2e/add-remove-items-from-renderer.html
@@ -34,9 +34,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 2.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/camera-manipulation-modes.html
+++ b/testing-e2e/camera-manipulation-modes.html
@@ -86,9 +86,7 @@
         console.log(msg)
         window.postMessage(msg)
       }
-      renderer.once('resized', () => {
-        postMessage('done-loading')
-      })
+      postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/camera-manipulator-walkmode.html
+++ b/testing-e2e/camera-manipulator-walkmode.html
@@ -52,9 +52,7 @@
       cameraManipulator.enabledWASDWalkMode = true
       cameraManipulator.getParameter('OrbitRate').setValue(0.5)
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/canvas-as-root.html
+++ b/testing-e2e/canvas-as-root.html
@@ -43,9 +43,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(3, 3, 9.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
     </script>
   </head>
   <body class="bg-blue-100">

--- a/testing-e2e/clear-geoms.html
+++ b/testing-e2e/clear-geoms.html
@@ -32,9 +32,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(3, 3, 1.7), new Vec3(0, 0, 0))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/clone-assetitem-before-load.html
+++ b/testing-e2e/clone-assetitem-before-load.html
@@ -44,10 +44,7 @@
       asset2.getParameter('LocalXfo').setValue(new Xfo(new Vec3(-0.5, 0, 0)))
       scene.getRoot().addChild(asset2)
 
-      Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
-        new Promise((resolve) => asset2.getGeometryLibrary().on('loaded', resolve)),
-      ]).then(() => {
+      Promise.all([new Promise((resolve) => asset2.getGeometryLibrary().on('loaded', resolve))]).then(() => {
         window.postMessage('done-loading')
       })
     </script>

--- a/testing-e2e/cone.html
+++ b/testing-e2e/cone.html
@@ -31,9 +31,7 @@
       const geomItem = new GeomItem('Cone', cone, standardMaterial)
       scene.getRoot().addChild(geomItem)
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/cuboid.html
+++ b/testing-e2e/cuboid.html
@@ -31,9 +31,7 @@
       const geomItem = new GeomItem('Cuboid', cuboid, standardMaterial)
       scene.getRoot().addChild(geomItem)
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/cutaways.html
+++ b/testing-e2e/cutaways.html
@@ -82,9 +82,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(25, 25, 13), new Vec3(10, 0, 0))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/cylinder.html
+++ b/testing-e2e/cylinder.html
@@ -30,9 +30,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/disc.html
+++ b/testing-e2e/disc.html
@@ -28,9 +28,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 2.7), new Vec3(0, 0, 0.4))
       // renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/env-map-viewer.html
+++ b/testing-e2e/env-map-viewer.html
@@ -71,10 +71,7 @@
       renderer.getViewport().getCamera().setLensFocalLength('20mm')
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 0, 0), new Vec3(0, 0, 0))
 
-      Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
-        new Promise((resolve) => envMap.once('loaded', resolve)),
-      ]).then(() => {
+      Promise.all([new Promise((resolve) => envMap.once('loaded', resolve))]).then(() => {
         window.postMessage('done-loading')
       })
 

--- a/testing-e2e/fat-lines.html
+++ b/testing-e2e/fat-lines.html
@@ -41,9 +41,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/fat-points.html
+++ b/testing-e2e/fat-points.html
@@ -47,9 +47,7 @@
       geomItem.getParameter('GlobalXfo').setValue(xfo)
       scene.getRoot().addChild(geomItem)
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/geomitem-material-changes.html
+++ b/testing-e2e/geomitem-material-changes.html
@@ -31,9 +31,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 2.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/geomitem-material-opacity-changes.html
+++ b/testing-e2e/geomitem-material-opacity-changes.html
@@ -31,9 +31,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 2.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/geomitem-material-opacity-continuous-changes.html
+++ b/testing-e2e/geomitem-material-opacity-continuous-changes.html
@@ -44,10 +44,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 5.7), new Vec3(0, 0, 2.4))
 
-      Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
-        new Promise((resolve) => envMap.once('loaded', resolve)),
-      ]).then(() => {
+      Promise.all([new Promise((resolve) => envMap.once('loaded', resolve))]).then(() => {
         window.postMessage('done-loading')
       })
 

--- a/testing-e2e/geomitem-visibility-changes.html
+++ b/testing-e2e/geomitem-visibility-changes.html
@@ -33,9 +33,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(5, 5, 2.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/grid.html
+++ b/testing-e2e/grid.html
@@ -26,9 +26,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 1.7), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
     </script>
   </body>
 </html>

--- a/testing-e2e/highlights.html
+++ b/testing-e2e/highlights.html
@@ -77,9 +77,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(25, 25, 13), new Vec3(10, 0, 0))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/kinematic-group.html
+++ b/testing-e2e/kinematic-group.html
@@ -69,9 +69,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(25, 25, 13), new Vec3(10, 0, 0))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/load-mesh-json.html
+++ b/testing-e2e/load-mesh-json.html
@@ -68,9 +68,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 1, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/load-obj-asset.html
+++ b/testing-e2e/load-obj-asset.html
@@ -40,7 +40,6 @@
       objAsset.getParameter('GlobalXfo').setValue(xfo)
 
       const promises = []
-      promises.push(new Promise((resolve) => renderer.once('resized', resolve)))
       promises.push(new Promise((resolve) => envMap.once('loaded', resolve)))
       promises.push(new Promise((resolve) => objAsset.once('loaded', resolve)))
       Promise.all(promises).then(() => {

--- a/testing-e2e/material-editor.html
+++ b/testing-e2e/material-editor.html
@@ -117,10 +117,7 @@
         material.getParameter('Reflectance').setValue(event.target.value / 100)
       })
 
-      Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
-        new Promise((resolve) => envMap.once('loaded', resolve)),
-      ]).then(() => {
+      Promise.all([new Promise((resolve) => envMap.once('loaded', resolve))]).then(() => {
         window.postMessage('done-loading')
       })
 

--- a/testing-e2e/material-group.html
+++ b/testing-e2e/material-group.html
@@ -89,9 +89,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(25, 25, 13), new Vec3(10, 0, 0))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/materials-emission.html
+++ b/testing-e2e/materials-emission.html
@@ -133,7 +133,6 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(35, -35, 25), new Vec3(0, 0, 0))
 
       Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
         new Promise((resolve) => envMap.once('loaded', resolve)),
       ]).then(() => {
         console.trace()

--- a/testing-e2e/materials-transparent.html
+++ b/testing-e2e/materials-transparent.html
@@ -123,10 +123,7 @@
 
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(35, -35, 25), new Vec3(0, 0, 0))
 
-      Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
-        new Promise((resolve) => envMap.once('loaded', resolve)),
-      ]).then(() => {
+      Promise.all([new Promise((resolve) => envMap.once('loaded', resolve))]).then(() => {
         window.postMessage('done-loading')
       })
 

--- a/testing-e2e/materials.html
+++ b/testing-e2e/materials.html
@@ -165,7 +165,6 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(35, -35, 20), new Vec3(0, 0, -10))
 
       Promise.all([
-        new Promise((resolve) => renderer.once('resized', resolve)),
         new Promise((resolve) => envMap.once('loaded', resolve)),
       ]).then(() => {
         window.postMessage('done-loading')

--- a/testing-e2e/multi-draw.html
+++ b/testing-e2e/multi-draw.html
@@ -151,9 +151,7 @@
       // scene.setupGrid(10.0, 10)
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(-15, -15, 5), new Vec3(0, 0, 0.4))
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/pbr-material.html
+++ b/testing-e2e/pbr-material.html
@@ -63,7 +63,6 @@
 
       // scene.setupGrid(10.0, 10)
       const promises = []
-      promises.push(new Promise((resolve) => renderer.once('resized', resolve)))
 
       const envMap = new EnvMap()
       envMap.getParameter('FilePath').setValue('data/pisa-webp.zenv')

--- a/testing-e2e/plane.html
+++ b/testing-e2e/plane.html
@@ -23,9 +23,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
     </script>
   </head>
   <body class="bg-blue-100">

--- a/testing-e2e/sphere.html
+++ b/testing-e2e/sphere.html
@@ -33,9 +33,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/textured-mesh.html
+++ b/testing-e2e/textured-mesh.html
@@ -28,7 +28,6 @@
       const plane = new Plane(1, 1)
 
       const promises = []
-      promises.push(new Promise((resolve) => renderer.once('resized', resolve)))
 
       {
         const material = new Material('Material', 'FlatSurfaceShader')

--- a/testing-e2e/torus.html
+++ b/testing-e2e/torus.html
@@ -29,9 +29,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(2, 2, 2.7), new Vec3(0, 0, 0.4))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {

--- a/testing-e2e/transparent-geoms-sorting-tinyscene.html
+++ b/testing-e2e/transparent-geoms-sorting-tinyscene.html
@@ -67,9 +67,7 @@
       addMeshShape(new Cylinder(0.0012, 0.004, 32, 2, true), -2, 8)
       addMeshShape(new Torus(0.0004, 0.0013), -3, 4)
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       document.querySelector('#back').addEventListener('click', () => {
         renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(-0.01, -0.02, 0.005), new Vec3(0.01, 0, 0))

--- a/testing-e2e/transparent-geoms-sorting.html
+++ b/testing-e2e/transparent-geoms-sorting.html
@@ -81,9 +81,7 @@
       renderer.getViewport().getCamera().setPositionAndTarget(new Vec3(25, 25, 13), new Vec3(10, 0, 0))
       renderer.frameAll()
 
-      renderer.once('resized', () => {
-        window.postMessage('done-loading')
-      })
+      window.postMessage('done-loading')
 
       // {{{ Messages handler.
       const handleMessage = (event) => {


### PR DESCRIPTION
canvas is now immediately resized to fit its parent container when the WebGL context is created, making renderer setup synchronous