### PR TITLE
fix: The frustum culling system would incorrectly cull items at the sides of the screen if those items had very large bounding spheres

### DIFF
--- a/cypress/integration/frustum-culling-long-geoms-spec.js
+++ b/cypress/integration/frustum-culling-long-geoms-spec.js
@@ -1,0 +1,19 @@
+describe('frustum-culling-long-geoms', () => {
+  it('Capture snapshots', () => {
+    cy.visit('testing-e2e/frustum-culling-long-geoms.html', {
+      onBeforeLoad(win) {
+        cy.spy(win, 'postMessage').as('postMessage')
+      },
+    })
+
+    cy.get('@postMessage').its('lastCall.args.0').should('equal', 'done-loading')
+    cy.get('canvas').percySnapshot('frustum-culling-long-geoms')
+
+    cy.window().then((win) => {
+      const variant = 'variant-01'
+      win.postMessage(variant)
+      cy.get('@postMessage').its('lastCall.args.0').should('equal', `done-${variant}`)
+      cy.get('canvas').percySnapshot(`frustum-culling-long-geoms - ${variant}`)
+    })
+  })
+})

--- a/src/Renderer/Drawing/GLGeomItemLibrary.js
+++ b/src/Renderer/Drawing/GLGeomItemLibrary.js
@@ -46,6 +46,9 @@ class GLGeomItemLibrary extends EventEmitter {
     this.worker.onmessage = (message) => {
       if (message.data.type == 'CullResults') {
         this.applyCullResults(message.data)
+      } else if (message.data.type == 'Done') {
+        // Used mostly to make our uni testing robust.
+        this.renderer.emit('CullingUpdated')
       }
       workerReady = true
     }

--- a/src/Renderer/Drawing/GLGeomItemLibraryCullingWorker.js
+++ b/src/Renderer/Drawing/GLGeomItemLibraryCullingWorker.js
@@ -17,16 +17,15 @@ const vec3_length = (vec) => {
   return Math.sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2])
 }
 const vec3_scale = (vec, scl) => {
-  return [vec[0] * len, vec[1] * len, vec[2] * len]
+  return [vec[0] * scl, vec[1] * scl, vec[2] * scl]
 }
-const vec3_angleTo = (vec1, vec2) => {
-  const cosine = vec3_dot(vec1, vec2)
-  if (cosine > 1.0) {
-    return 0
-  } else {
-    return Math.acos(cosine)
-  }
+const vec2_scale = (vec, scl) => {
+  return [vec[0] * scl, vec[1] * scl]
 }
+const vec2_length = (vec) => {
+  return Math.sqrt(vec[0] * vec[0] + vec[1] * vec[1])
+}
+
 const quat_conjugate = (quat) => {
   return [-quat[0], -quat[1], -quat[2], quat[3]]
 }
@@ -99,26 +98,46 @@ const checkGeomItem = (geomItemData) => {
     unCull(geomItemData.id)
     return
   }
-  const viewVec = quat_rotateVec3(viewInvOri, vec)
-  // Cull items behind the view.
-  if (viewVec[2] > 0) {
-    cull(geomItemData.id)
-    return
-  }
-
   // Cull very small items
   // Note: when in VR, the FoV becomes very wide and the pixel
-  // height varies. It seems more consistent to just use solidAngle,
+  // height varies. It seems more consistent to just use solidAngle
   // which is resolution invariant.
-  const solidAngle = Math.atan(boundingRadius / dist)
+  const solidAngle = Math.asin(boundingRadius / dist)
   if (solidAngle < 0.004) {
     cull(geomItemData.id)
     return
   }
 
-  const viewVecNorm = vec3_normalize(viewVec)
-  const viewAngle = [Math.abs(Math.asin(viewVecNorm[0])) - solidAngle, Math.abs(Math.asin(viewVecNorm[1])) - solidAngle]
-  // console.log(geomItemData.id, 'angle To Sphere:', frustumHalfAngleX - viewAngle[0], frustumHalfAngleY - viewAngle[1])
+  // Now we check if the item is within the view frustum.
+  // We need the solid angle of the item for each axis (X & Y)
+  // This is because at the corners of the screen, the object is slightly
+  // further away, so the solid angle calculated above gets smaller.
+  // This was causing items with big bounding spheres to be culled too early
+  // at the corner of the screen.
+  const viewVec = quat_rotateVec3(viewInvOri, vec)
+  const viewVecXZ = [viewVec[0], viewVec[2]]
+  const viewVecYZ = [viewVec[1], viewVec[2]]
+  const distX = vec2_length(viewVecXZ)
+  const distY = vec2_length(viewVecYZ)
+  const solidAngleXZ = Math.asin(boundingRadius / distX)
+  const solidAngleYZ = Math.asin(boundingRadius / distY)
+  const viewVecNormXZ = vec2_scale(viewVecXZ, 1 / distX)
+  const viewVecNormYZ = vec2_scale(viewVecYZ, 1 / distY)
+
+  let viewAngle
+  // If an item is behind the viewer
+  if (viewVec[2] > 0) {
+    viewAngle = [
+      Math.PI - Math.abs(Math.asin(viewVecNormXZ[0])) - solidAngleXZ,
+      Math.PI - Math.abs(Math.asin(viewVecNormYZ[0])) - solidAngleYZ,
+    ]
+  } else {
+    viewAngle = [
+      Math.abs(Math.asin(viewVecNormXZ[0])) - solidAngleXZ,
+      Math.abs(Math.asin(viewVecNormYZ[0])) - solidAngleYZ,
+    ]
+  }
+  // console.log(geomItemData.id, 'angle To Item:', frustumHalfAngleX, viewAngle[0], frustumHalfAngleY, viewAngle[1])
   if (viewAngle[0] > frustumHalfAngleX || viewAngle[1] > frustumHalfAngleY) {
     cull(geomItemData.id)
     return

--- a/testing-e2e/frustum-culling-long-geoms.html
+++ b/testing-e2e/frustum-culling-long-geoms.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>frustum-culling-long-geoms - Zea Engine</title>
+
+    <link href="data/zea-logo.png" rel="shortcut icon" />
+
+    <link rel="stylesheet" href="styles/tailwind.min.css" />
+
+    <script src="../dist/index.umd.js"></script>
+    <script src="../dist/plugins.umd.js"></script>
+
+    <script type="module">
+      const { GLRenderer, Scene, Vec3, Xfo, Color, Sphere, Cuboid, Material, GeomItem, GLBoundingBoxPass } = zeaEngine
+
+      const canvas = document.querySelector('#renderer')
+
+      const scene = new Scene()
+      const renderer = new GLRenderer(canvas, { hideSplash: true, webglOptions: { antialias: false } })
+      renderer.setScene(scene)
+
+      scene.setupGrid(10.0, 10)
+      const beam = new Cuboid(25, 0.5, 0.5)
+
+      const material = new Material('surfaces', 'SimpleSurfaceShader')
+      let count = 10
+      for (let i = 0; i < count; i++) {
+        const longGeom = new GeomItem(
+          'longCuboid' + i,
+          new Cuboid(25, 0.5, 0.5),
+          material,
+          new Xfo(new Vec3(25, 0, i - 5))
+        )
+        scene.getRoot().addChild(longGeom)
+      }
+
+      const camera = renderer.getViewport().getCamera()
+      camera.setPositionAndTarget(new Vec3(15.8556, 13.39021, 0.92746), new Vec3(5.19458, -3.34824, -0.09665))
+      // renderer.getViewport().on('viewChanged', (event) => {
+      //   console.log(camera.getParameter('GlobalXfo').getValue().toString(), camera.getTargetPosition().toString())
+      // })
+
+      const postMessage = (msg) => {
+        console.log(msg)
+        window.postMessage(msg)
+      }
+      postMessage('done-loading')
+
+      // {{{ Messages handler.
+      const handleMessage = (event) => {
+        const { data } = event
+        if (data === 'variant-01') {
+          camera.setPositionAndTarget(new Vec3(14.15735, 14.55242, -0.38921), new Vec3(3.49633, -2.18602, -1.41332))
+          renderer.once('CullingUpdated', () => {
+            postMessage(`done-${data}`)
+          })
+        }
+      }
+
+      window.addEventListener('message', handleMessage, false)
+      // }}}
+    </script>
+  </head>
+  <body class="bg-blue-100">
+    <div class="h-screen">
+      <canvas class="absolute" id="renderer"></canvas>
+    </div>
+  </body>
+</html>

--- a/testing-e2e/index.html
+++ b/testing-e2e/index.html
@@ -29,6 +29,7 @@
       <li><a href="camera-manipulation-modes.html">camera-manipulation-modes</a></li>
       <li><a href="camera-manipulator-walkmode.html">camera-manipulator-walkmode</a></li>
       <li><a href="frustum-culling.html">frustum-culling</a></li>
+      <li><a href="frustum-culling-long-geoms.html">frustum-culling-long-geoms</a></li>
       <li><a href="geomitem-geometry-changes.html">geomitem-geometry-changes</a></li>
       <li><a href="geomitem-material-changes.html">geomitem-material-changes</a></li>
       <li><a href="geomitem-visibility-changes.html">geomitem-visibility-changes</a></li>


### PR DESCRIPTION
This was due to incorrect math calculating the solid angle of the items.