### PR TITLE
refactor: This change puts back the system of providing material templates using static methods

### DIFF
--- a/src/Renderer/GLShader.ts
+++ b/src/Renderer/GLShader.ts
@@ -511,7 +511,7 @@ class GLShader extends BaseItem {
    * @return - The template material value.
    */
   static getMaterialTemplate(): Material {
-    return materialTemplate
+    throw new Error('Shader does not provide a material template.')
   }
 
   // /////////////////////////////////

--- a/src/Renderer/GLShader.ts
+++ b/src/Renderer/GLShader.ts
@@ -504,6 +504,16 @@ class GLShader extends BaseItem {
     return matData
   }
 
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return materialTemplate
+  }
+
   // /////////////////////////////////
   // Destroy
 
@@ -521,5 +531,6 @@ class GLShader extends BaseItem {
     this.__shaderProgramHdls = {}
   }
 }
+const materialTemplate = new Material()
 
 export { GLShader }

--- a/src/Renderer/ShaderLibrary.ts
+++ b/src/Renderer/ShaderLibrary.ts
@@ -270,14 +270,6 @@ class ShaderLibrary {
     // console.log(result.glsl)
     return result
   }
-
-  registerMaterialTemplate(shaderName: string, materialTemplate: any) {
-    this.materialTemplates[shaderName] = materialTemplate
-  }
-
-  getMaterialTemplate(shaderName: string) {
-    return this.materialTemplates[shaderName]
-  }
 }
 
 const shaderLibrary = new ShaderLibrary()

--- a/src/Renderer/Shaders/EnvProjectionShader.ts
+++ b/src/Renderer/Shaders/EnvProjectionShader.ts
@@ -48,8 +48,7 @@ class LatLongEnvProjectionShader extends EnvProjectionShader {
   }
 }
 
-// Registry.register('LatLongEnvProjectionShader', LatLongEnvProjectionShader)
-export { EnvProjectionShader, OctahedralEnvProjectionShader, LatLongEnvProjectionShader }
 const material = new Material('EnvProjectionShader_template')
 material.addParameter(new Vec3Parameter('projectionCenter', new Vec3(0.0, 0.0, 1.7)))
-shaderLibrary.registerMaterialTemplate('EnvProjectionShader', material)
+
+export { EnvProjectionShader, OctahedralEnvProjectionShader, LatLongEnvProjectionShader }

--- a/src/Renderer/Shaders/FatLinesShader.ts
+++ b/src/Renderer/Shaders/FatLinesShader.ts
@@ -43,6 +43,16 @@ class FatLinesShader extends GLShader {
   static supportsInstancing() {
     return false
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 Registry.register('FatLinesShader', FatLinesShader)
@@ -52,6 +62,5 @@ material.addParameter(new MaterialColorParam('BaseColor', new Color(1.0, 1, 0.5)
 material.addParameter(new NumberParameter('Opacity', 1.0))
 material.addParameter(new NumberParameter('LineThickness', 0.01))
 material.addParameter(new NumberParameter('Overlay', 0.0))
-shaderLibrary.registerMaterialTemplate('FatLinesShader', material)
 
 export { FatLinesShader }

--- a/src/Renderer/Shaders/FatPointsShader.ts
+++ b/src/Renderer/Shaders/FatPointsShader.ts
@@ -36,6 +36,16 @@ class FatPointsShader extends GLShader {
   static supportsInstancing() {
     return false
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 const material = new Material('LinesShader_template')
@@ -44,8 +54,6 @@ material.addParameter(new NumberParameter('PointSize', 1.0, [0, 1]))
 material.addParameter(new NumberParameter('Rounded', 1.0))
 material.addParameter(new NumberParameter('BorderWidth', 0.2))
 material.addParameter(new NumberParameter('Overlay', 0.0))
-
-shaderLibrary.registerMaterialTemplate('FatPointsShader', material)
 
 Registry.register('FatPointsShader', FatPointsShader)
 

--- a/src/Renderer/Shaders/FlatSurfaceShader.ts
+++ b/src/Renderer/Shaders/FlatSurfaceShader.ts
@@ -67,12 +67,21 @@ class FlatSurfaceShader extends GLShader {
     matData[3] = baseColor.a
     return matData
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 export { FlatSurfaceShader }
 
 const material = new Material('StandardSurfaceShader_template')
 material.addParameter(new MaterialColorParam('BaseColor', new Color(1.0, 1, 0.5)))
-shaderLibrary.registerMaterialTemplate('FlatSurfaceShader', material)
 
 Registry.register('FlatSurfaceShader', FlatSurfaceShader)

--- a/src/Renderer/Shaders/LinesShader.ts
+++ b/src/Renderer/Shaders/LinesShader.ts
@@ -47,6 +47,16 @@ class LinesShader extends GLShader {
     matData[8] = material.getParameter('OccludedStippleValue')!.value
     return matData
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 const material = new Material('LinesShader_template')
@@ -59,7 +69,6 @@ material.addParameter(new NumberParameter('StippleScale', 0.01))
 material.addParameter(new NumberParameter('StippleValue', 0, [0, 1]))
 
 material.addParameter(new NumberParameter('OccludedStippleValue', 1.0, [0, 1]))
-shaderLibrary.registerMaterialTemplate('LinesShader', material)
 
 Registry.register('LinesShader', LinesShader)
 

--- a/src/Renderer/Shaders/PointsShader.ts
+++ b/src/Renderer/Shaders/PointsShader.ts
@@ -47,6 +47,5 @@ const material = new Material('PointsShader_template')
 material.addParameter(new MaterialColorParam('BaseColor', new Color(1.0, 1, 0.5)))
 material.addParameter(new NumberParameter('PointSize', 2))
 material.addParameter(new NumberParameter('Overlay', 0.00002))
-shaderLibrary.registerMaterialTemplate('PointsShader', material)
 
 Registry.register('PointsShader', PointsShader)

--- a/src/Renderer/Shaders/PointsShader.ts
+++ b/src/Renderer/Shaders/PointsShader.ts
@@ -39,6 +39,16 @@ class PointsShader extends GLShader {
     matData[5] = material.getParameter('Overlay')!.value
     return matData
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 export { PointsShader }

--- a/src/Renderer/Shaders/ScreenSpaceShader.ts
+++ b/src/Renderer/Shaders/ScreenSpaceShader.ts
@@ -42,6 +42,16 @@ class ScreenSpaceShader extends GLShader {
     matData[3] = baseColor.a
     return matData
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 const material = new Material('ScreenSpaceShader_template')

--- a/src/Renderer/Shaders/ScreenSpaceShader.ts
+++ b/src/Renderer/Shaders/ScreenSpaceShader.ts
@@ -46,7 +46,6 @@ class ScreenSpaceShader extends GLShader {
 
 const material = new Material('ScreenSpaceShader_template')
 material.addParameter(new MaterialColorParam('BaseColor', new Color(1.0, 1, 0.5)))
-shaderLibrary.registerMaterialTemplate('ScreenSpaceShader', material)
 
 Registry.register('ScreenSpaceShader', ScreenSpaceShader)
 

--- a/src/Renderer/Shaders/SimpleSurfaceShader.ts
+++ b/src/Renderer/Shaders/SimpleSurfaceShader.ts
@@ -43,14 +43,23 @@ class SimpleSurfaceShader extends GLShader {
     matData[5] = material.getParameter('EmissiveStrength')!.value
     return matData
   }
-}
 
-export { SimpleSurfaceShader }
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
+}
 
 const material = new Material('StandardSurfaceShader_template')
 material.addParameter(new MaterialColorParam('BaseColor', new Color(1.0, 1, 0.5)))
 material.addParameter(new MaterialFloatParam('Opacity', 1, [0, 1]))
 material.addParameter(new MaterialFloatParam('EmissiveStrength', 0, [0, 1]))
-shaderLibrary.registerMaterialTemplate('SimpleSurfaceShader', material)
 
 Registry.register('SimpleSurfaceShader', SimpleSurfaceShader)
+
+export { SimpleSurfaceShader }

--- a/src/Renderer/Shaders/StandardSurfaceShader.ts
+++ b/src/Renderer/Shaders/StandardSurfaceShader.ts
@@ -74,6 +74,16 @@ class StandardSurfaceShader extends GLShader {
 
     return matData
   }
+
+  /**
+   * Each shader provides a template material that each material instance is
+   * based on. The shader specifies the parameters needed by the shader, and
+   * the material provides values to the shader during rendering.
+   * @return - The template material value.
+   */
+  static getMaterialTemplate(): Material {
+    return material
+  }
 }
 
 const material = new Material('StandardSurfaceShader_template')
@@ -85,9 +95,6 @@ material.addParameter(new MaterialFloatParam('Roughness', 0.5, [0, 1])) // added
 material.addParameter(new MaterialFloatParam('Reflectance', 0.5, [0, 1]))
 material.addParameter(new MaterialFloatParam('EmissiveStrength', 0, [0, 1]))
 material.addParameter(new MaterialFloatParam('Opacity', 1, [0, 1]))
-
-shaderLibrary.registerMaterialTemplate('StandardSurfaceShader', material)
-shaderLibrary.registerMaterialTemplate('TransparentSurfaceShader', material)
 
 Registry.register('StandardSurfaceShader', StandardSurfaceShader)
 Registry.register('TransparentSurfaceShader', StandardSurfaceShader)

--- a/src/SceneTree/Material.ts
+++ b/src/SceneTree/Material.ts
@@ -64,7 +64,8 @@ class Material extends BaseItem {
     if (this.__shaderName == shaderName) return
     this.__shaderName = shaderName
 
-    const materialTemplate = shaderLibrary.getMaterialTemplate(shaderName)
+    const shaderClass = <typeof GLShader>Registry.getClassDefinition(shaderName)
+    const materialTemplate = shaderClass.getMaterialTemplate()
     if (!materialTemplate) throw new Error('Error setting Shader. Material template not registered found:' + shaderName)
 
     const paramMap: { [key: string]: boolean } = {}

--- a/testing-e2e/pointer-events.html
+++ b/testing-e2e/pointer-events.html
@@ -51,7 +51,6 @@
         }
       }
       Registry.register('OverlayShader', OverlayShader)
-      shaderLibrary.registerMaterialTemplate('OverlayShader', shaderLibrary.getMaterialTemplate('SimpleSurfaceShader'))
 
       const scene = new Scene()
       const renderer = new GLRenderer(document.getElementById('viewport'), {


### PR DESCRIPTION
- This change puts back the system of providing material templates using static methods instead of registering them with the shaderLibrary.
- This has the benefit that derived shaders don't need to provide a new template if they don't add new parameters.