### PR TITLE
fix: instance-item clones children of reference item instead of Reference Item.

### DIFF
--- a/src/SceneTree/InstanceItem.ts
+++ b/src/SceneTree/InstanceItem.ts
@@ -27,9 +27,18 @@ class InstanceItem extends TreeItem {
    */
   setSrcTree(treeItem: TreeItem, context: Record<string, any>) {
     this.srcTree = treeItem
-    const clonedTree = this.srcTree.clone(context)
-    clonedTree.localXfoParam.value = new Xfo()
-    this.addChild(clonedTree, false)
+    const numChildren = this.srcTree.getNumChildren()
+    if (numChildren == 0) {
+      const clonedTree = this.srcTree.clone(context)
+      clonedTree.localXfoParam.loadValue(new Xfo())
+      this.addChild(clonedTree, false)
+    } else {
+      const children = this.srcTree.getChildren()
+      children.forEach((child) => {
+        const clonedChild = child.clone(context)
+        this.addChild(clonedChild, false)
+      })
+    }
   }
 
   /**
@@ -109,7 +118,6 @@ class InstanceItem extends TreeItem {
     cloned.copyFrom(this, context)
     return cloned
   }
-
 }
 
 Registry.register('InstanceItem', InstanceItem)


### PR DESCRIPTION
Note: this changes the structure of the tree, by reducing the depth by 1 at each Instance node.