### PR TITLE
fix: XRefs in large shattered assemblies would cause name collisions

### DIFF
--- a/src/SceneTree/AssetLoadContext.ts
+++ b/src/SceneTree/AssetLoadContext.ts
@@ -21,7 +21,7 @@ export class AssetLoadContext extends EventEmitter {
   folder: string = ''
   camera: Camera = null
   assetItem: AssetItem = null
-  resources: Record<string, string> = {} // a mapping of the key to asset urls.
+  resources: Record<string, string> | null = null // a mapping of the key to asset urls.
   xrefs: Record<string, XRef> = {} // a mapping of the xrefs that have been loaded to their paths.
   numTreeItems: number = 0
   numGeomItems: number = 0
@@ -35,9 +35,11 @@ export class AssetLoadContext extends EventEmitter {
    */
   constructor(context?: AssetLoadContext) {
     super()
-    this.units = context ? context.units : 'meters'
-    this.xrefs = context ? context.xrefs : {}
-    this.resources = context ? context.resources : {}
+    if (context) {
+      this.units = context.units
+      this.xrefs = context.xrefs
+      this.resources = context.resources
+    }
   }
 
   /**

--- a/src/SceneTree/AssetLoadContext.ts
+++ b/src/SceneTree/AssetLoadContext.ts
@@ -5,6 +5,7 @@ import { Parameter } from './Parameters/Parameter'
 import { AssetItem } from './AssetItem'
 import { BaseGeomItem } from './BaseGeomItem'
 import { Camera } from './Camera'
+import { XRef } from './CAD'
 
 /**
  * Provides a context for loading assets. This context can provide the units of the loading scene.
@@ -14,14 +15,14 @@ import { Camera } from './Camera'
  */
 export class AssetLoadContext extends EventEmitter {
   units: string = 'meters'
-  protected assets: Record<string, any> = {}
-  protected resources: Record<string, any> = {}
   versions: Record<string, Version> = {}
   sdk: string = ''
   url: string = ''
   folder: string = ''
   camera: Camera = null
   assetItem: AssetItem = null
+  resources: Record<string, string> = {} // a mapping of the key to asset urls.
+  xrefs: Record<string, XRef> = {} // a mapping of the xrefs that have been loaded to their paths.
   numTreeItems: number = 0
   numGeomItems: number = 0
   protected postLoadCallbacks: Array<() => void> = []
@@ -35,7 +36,7 @@ export class AssetLoadContext extends EventEmitter {
   constructor(context?: AssetLoadContext) {
     super()
     this.units = context ? context.units : 'meters'
-    this.assets = context ? context.assets : {}
+    this.xrefs = context ? context.xrefs : {}
     this.resources = context ? context.resources : {}
   }
 

--- a/src/SceneTree/CAD/XRef.ts
+++ b/src/SceneTree/CAD/XRef.ts
@@ -76,28 +76,36 @@ class XRef extends CADAsset {
       if (name == '') this.setName(relativePath)
     }
 
-    // @ts-ignore will be fixed in #579
-    if (!context.resources[relativePath]) {
-      // CAD systems seem to have flexible path resolution strategies that we can't support.
-      // e.g. looking in multiple folders for a file.
-      // The relative paths often break.
-      // If the user provides a mapping table, we will use it, else
-      // we assume files will all be in the same folder.
-      if (relativePath.includes('/')) {
-        relativePath = relativePath.slice(relativePath.lastIndexOf('/') + 1)
-      } else if (relativePath.includes('\\')) {
-        relativePath = relativePath.slice(relativePath.lastIndexOf('\\') + 1)
+    // /////////////////////////////////////
+    // URL
+    // If a resources dict has been provided, look it up, else
+    // generate a url.
+    let url
+    if (context.resources) {
+      if (context.resources[relativePath]) {
+        url = context.resources[relativePath]
+      } else {
+        // CAD systems seem to have flexible path resolution strategies that we dont yet support.
+        // e.g. looking in multiple folders for a file.
+        // The relative paths often break.
+        // If the user provides a mapping table, we will use it, else
+        // we assume files will all be in the same folder.
+        if (relativePath.includes('/')) {
+          relativePath = relativePath.slice(relativePath.lastIndexOf('/') + 1)
+        } else if (relativePath.includes('\\')) {
+          relativePath = relativePath.slice(relativePath.lastIndexOf('\\') + 1)
+        }
+        if (context.resources[relativePath]) {
+          url = context.resources[relativePath]
+        }
       }
-      // @ts-ignore will be fixed in #579
-      if (!context.resources[relativePath]) {
-        // @ts-ignore will be fixed in #579
-        context.resources[relativePath] = context.folder + relativePath + '.zcad'
-      }
+    } else {
+      // Generate a url relative to the folder of the asset we are currently loading.
+      url = context.folder + relativePath + '.zcad'
     }
 
-    if (context.resources[relativePath]) {
-      // console.log('resolving XRef:', relativePath, ' > ', context.resources[relativePath])
-      const url = context.resources[relativePath]
+    if (url) {
+      // console.log('resolving XRef:', relativePath, ' > ', url)
       context.incrementAsync()
 
       // If an XRef already exists to the same zcad file, we can just clone the existing XRef.


### PR DESCRIPTION
 
XRefs in large shattered assemblies would cause name collisions due to losing thier unique name.